### PR TITLE
Copy param --save_date_time from big-sleep; Leftpadding sequence with six zeroes; refactoring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -134,3 +134,4 @@ dmypy.json
 
 output/
 run.py
+run.sh

--- a/.gitignore
+++ b/.gitignore
@@ -128,6 +128,9 @@ dmypy.json
 # Pyre type checker
 .pyre/
 
+# IDEs
 .vscode/
-output/
 .idea/
+
+output/
+run.py

--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ $ imagine "stranger in strange lands" --num-layers 32
 ```
 
 ## Usage
+
+### CLI
 ```bash
 NAME
     imagine
@@ -124,17 +126,72 @@ FLAGS
         Save files with a timestamp prepended e.g. `%y%m%d-%H%M%S-my_phrase_here`
 ```
 
-If you would like to invoke it in code.
-
+### Python
+#### Invoke `deep_daze.Imagine` in Python
 ```python
 from deep_daze import Imagine
 
 imagine = Imagine(
     text = 'cosmic love and attention',
-    num_layers = 24
+    num_layers = 24,
 )
-
 imagine()
+```
+
+#### Save progress every fourth iteration
+Save images in the format insert_text_here.00001.png, insert_text_here.00002.png, ...up to `(total_iterations % save_every)`
+```python
+imagine = Imagine(
+    text=text,
+    save_every=4,
+    save_progress=True
+)
+```
+
+#### Prepend current timestamp on each image.
+Creates files with both the timestamp and the sequence number.
+
+e.g. 210129-043928_328751_insert_text_here.00001.png, 210129-043928_512351_insert_text_here.00002.png, ...
+```python
+imagine = Imagine(
+    text=text,
+    save_every=4,
+    save_progress=True,
+    save_date_time=True,
+)
+```
+
+#### High GPU memory usage
+If you have at least 16 GiB of vram available, you should be able to run these settings with some wiggle room.
+```python
+imagine = Imagine(
+    text=text,
+    num_layers=42,
+    batch_size=64,
+    gradient_accumulate_every=1,
+)
+```
+
+#### Average GPU memory usage
+```python
+imagine = Imagine(
+    text=text,
+    num_layers=24,
+    batch_size=16,
+    gradient_accumulate_every=2
+)
+```
+
+#### Very low GPU memory usage (less than 4 GiB)
+If you are desperate to run this on a card with less than 8 GiB vram, you can lower the image_width.
+```python
+imagine = Imagine(
+    text=text,
+    image_width=256,
+    num_layers=16,
+    batch_size=1,
+    gradient_accumulate_every=16 # Increase gradient_accumulate_every to correct for loss in low batch sizes
+)
 ```
 
 ## Where is this going?

--- a/README.md
+++ b/README.md
@@ -119,7 +119,9 @@ FLAGS
     --open_folder=OPEN_FOLDER
         Default: True
         Whether or not to open a folder showing your generated images.
-
+    --save_date_time=SAVE_DATE_TIME
+        Default: False
+        Save files with a timestamp prepended e.g. `%y%m%d-%H%M%S-my_phrase_here`
 ```
 
 If you would like to invoke it in code.

--- a/deep_daze/cli.py
+++ b/deep_daze/cli.py
@@ -19,7 +19,8 @@ def train(
         overwrite=False,
         save_progress=False,
         seed=None,
-        open_folder=True
+        open_folder=True,
+        save_date_time=False
 ):
     """
     :param text: (required) A phrase less than 77 characters which you would like to visualize.
@@ -36,7 +37,7 @@ def train(
     :param deeper: Uses a Siren neural net with 32 hidden layers.
     :param image_width: The desired resolution of the image.
     :param seed: A seed to be used for deterministic runs.
-
+    :param save_date_time: Save files with a timestamp prepended e.g. `%y%m%d-%H%M%S-my_phrase_here`
     """
     print('Starting up...')
 
@@ -55,7 +56,8 @@ def train(
         save_every=save_every,
         save_progress=save_progress,
         seed=seed,
-        open_folder=open_folder
+        open_folder=open_folder,
+        save_date_time=save_date_time
     )
 
     if not overwrite and imagine.filename.exists():

--- a/deep_daze/cli.py
+++ b/deep_daze/cli.py
@@ -37,7 +37,7 @@ def train(
     :param deeper: Uses a Siren neural net with 32 hidden layers.
     :param image_width: The desired resolution of the image.
     :param seed: A seed to be used for deterministic runs.
-    :param save_date_time: Save files with a timestamp prepended e.g. `%y%m%d-%H%M%S-my_phrase_here`
+    :param save_date_time: Save files with a timestamp prepended e.g. `%y%m%d-%H%M%S-my_phrase_here.png`
     """
     # Don't instantiate imagine if the user just wants help.
     if any("--help" in arg for arg in sys.argv):

--- a/deep_daze/cli.py
+++ b/deep_daze/cli.py
@@ -39,10 +39,12 @@ def train(
     :param seed: A seed to be used for deterministic runs.
     :param save_date_time: Save files with a timestamp prepended e.g. `%y%m%d-%H%M%S-my_phrase_here`
     """
-    print('Starting up...')
+    # Don't instantiate imagine if the user just wants help.
+    if any("--help" in arg for arg in sys.argv):
+        print("Type `imagine --help` for usage info.")
+        sys.exit()
 
-    if deeper:
-        num_layers = 32
+    num_layers = 32 if deeper else num_layers
 
     imagine = Imagine(
         text,
@@ -60,6 +62,7 @@ def train(
         save_date_time=save_date_time
     )
 
+    print('Starting up...')
     if not overwrite and imagine.filename.exists():
         answer = input('Imagined image already exists, do you want to overwrite? (y/n) ').lower()
         if answer not in ('yes', 'y'):

--- a/deep_daze/clip.py
+++ b/deep_daze/clip.py
@@ -163,6 +163,11 @@ def _download(url, root=os.path.expanduser("~/.cache/clip")):
 
 
 def load():
+    """
+    Downloads the existing CLIP model if necessary, finds and patches devices, then returns a torch model
+    and a Normalize containing the mean and standard deviation of the CLIP training set.
+    :rtype: tuple[Union[RecursiveScriptModule, RecursiveScriptModule], Normalize]
+    """
     device = 'cuda'
     model_path = _download(MODEL_PATH)
     model = torch.jit.load(model_path, map_location=device).eval()

--- a/deep_daze/deep_daze.py
+++ b/deep_daze/deep_daze.py
@@ -5,7 +5,7 @@ import sys
 import random
 from datetime import datetime
 from pathlib import Path
-from shutil import copyfile
+from shutil import copy2
 
 import torch
 import torch.nn.functional as F
@@ -269,7 +269,7 @@ class Imagine(nn.Module):
             img.clamp_(0., 1.)
             self.filename = custom_filename if custom_filename else self.image_output_path(current_iteration=current_iteration)
             save_image(img, self.filename)
-            copyfile(str(self.filename), f"{self.textpath}.png")
+            copy2(str(self.filename), f"{self.textpath}.png")
             tqdm.write(f'image updated at "./{str(self.filename)}"')
 
     def train_step(self, epoch, iteration):

--- a/deep_daze/deep_daze.py
+++ b/deep_daze/deep_daze.py
@@ -5,7 +5,7 @@ import sys
 import random
 from datetime import datetime
 from pathlib import Path
-from shutil import copy2
+from shutil import copy
 
 import torch
 import torch.nn.functional as F
@@ -269,7 +269,7 @@ class Imagine(nn.Module):
             img.clamp_(0., 1.)
             self.filename = custom_filename if custom_filename else self.image_output_path(current_iteration=current_iteration)
             save_image(img, self.filename)
-            copy2(str(self.filename), f"{self.textpath}.png")
+            copy(str(self.filename), f"{self.textpath}.png")
             tqdm.write(f'image updated at "./{str(self.filename)}"')
 
     def train_step(self, epoch, iteration):

--- a/deep_daze/deep_daze.py
+++ b/deep_daze/deep_daze.py
@@ -3,6 +3,7 @@ import signal
 import subprocess
 import sys
 import random
+from datetime import datetime
 from pathlib import Path
 
 import torch
@@ -206,7 +207,8 @@ class Imagine(nn.Module):
             iterations=1050,
             save_progress=False,
             seed=None,
-            open_folder=True
+            open_folder=True,
+            save_date_time=False
     ):
         super().__init__()
 
@@ -229,22 +231,23 @@ class Imagine(nn.Module):
         ).cuda()
 
         self.model = model
-
         self.scaler = GradScaler()
         self.optimizer = Adam(model.parameters(), lr)
         self.gradient_accumulate_every = gradient_accumulate_every
         self.save_every = save_every
+        self.save_date_time = save_date_time
+        self.open_folder = open_folder
 
+        self.set_text(text)
+
+    def set_text(self, text):
         self.text = text
         textpath = self.text.replace(' ', '_')
-
+        if self.save_date_time:
+            textpath = datetime.now().strftime("%y%m%d-%H%M%S-") + textpath
         self.textpath = textpath
         self.filename = Path(f'./{textpath}.png')
-        self.save_progress = save_progress
-
         self.encoded_text = tokenize(text).cuda()
-
-        self.open_folder = open_folder
 
     def train_step(self, epoch, i):
         total_loss = 0

--- a/deep_daze/deep_daze.py
+++ b/deep_daze/deep_daze.py
@@ -259,6 +259,16 @@ class Imagine(nn.Module):
             output_path = f"{current_time}_{output_path}"
         return Path(f"{output_path}.png")
 
+    def replace_current_img(self):
+        """
+        Replace the current file at {text_path}.png with the current self.filename
+        """
+        always_current_img = f"{self.textpath}.png"
+        if os.path.isfile(always_current_img) or os.path.islink(always_current_img):
+            os.remove(always_current_img)  # remove the file
+
+        copy(str(self.filename), always_current_img)
+
     def generate_and_save_image(self, custom_filename: Path = None, current_iteration: int = None):
         """
         :param current_iteration:
@@ -269,10 +279,11 @@ class Imagine(nn.Module):
             img.clamp_(0., 1.)
             self.filename = custom_filename if custom_filename else self.image_output_path(current_iteration=current_iteration)
             save_image(img, self.filename)
-            copy(str(self.filename), f"{self.textpath}.png")
+            self.replace_current_image()
             tqdm.write(f'image updated at "./{str(self.filename)}"')
 
-    def train_step(self, epoch, iteration):
+
+    def train_step(self, epoch, iteration) -> int:
         total_loss = 0
 
         for _ in range(self.gradient_accumulate_every):


### PR DESCRIPTION
- Implemented the same functionality as the --save_date_time parameter from your big-sleep repo.
- Made image generation more efficient. Before, two images were generated, one for --save_progress and another for --save_every. Now a single image is generated and copied.
- Now leftpadding the sequence number for image paths with 6 zeros. Should fix alphabetic sorting.
- More python usage in README. Various configurations for different hardware setups. 
- Switch print to tqdm.write() in deep-daze.py so we don't interrupt the tqdm progress bar. 