### PR TITLE
 --theta_initial and --theta-hidden README/docstring updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,12 @@ FLAGS
     --start_image_train_iters=START_IMAGE_TRAIN_ITERS
         Default: 50
         The number of steps for the initial training on the starting image
+    --theta_initial=THETA_INITIAL
+        Default: 30.0
+        Hyperparameter describing the frequency of the color space. Only applies to the first layer of the network.
+    --theta_hidden=THETA_INITIAL
+        Default: 30.0
+        Hyperparameter describing the frequency of the color space. Only applies to the hidden layers of the network.
 ```
 
 ### Priming

--- a/deep_daze/cli.py
+++ b/deep_daze/cli.py
@@ -46,6 +46,8 @@ def train(
     :param save_date_time: Save files with a timestamp prepended e.g. `%y%m%d-%H%M%S-my_phrase_here.png`
     :param start_image_path: Path to the image you would like to prime the generator with initially
     :param start_image_train_iters: Number of iterations for priming, defaults to 50
+    :param theta_initial: Hyperparameter describing the frequency of the color space. Only applies to the first layer of the network.
+    :param theta_hidden: Hyperparameter describing the frequency of the color space. Only applies to the hidden layers of the network.
     :param start_image_lr: Learning rate for the start image training.
     """
     # Don't instantiate imagine if the user just wants help.


### PR DESCRIPTION
Just changed the README and the docstring. Tested help and it _does_ output type Optional instead of 30.0, but I agree that the default should probably actually just be None so we don't have to change code in 9 places whenever we change the default. 

Should be good to merge. Lemme know if you want me to just put "optional" in the README as well. 