### PR TITLE
Img encoding

### DIFF
--- a/deep_daze/deep_daze.py
+++ b/deep_daze/deep_daze.py
@@ -317,7 +317,7 @@ class Imagine(nn.Module):
         self.text = text
         self.img = img
         if encoding is not None:
-            return encoding
+            return encoding.cuda()
         elif text is not None:
             return self.create_text_encoding(text)
         elif img is not None:
@@ -336,7 +336,7 @@ class Imagine(nn.Module):
         return img_encoding
     
     def set_clip_encoding(self, text=None, img=None, encoding=None):
-        encoding = self.create_clip_encoding(text=text, img=img, encoding=encoding)
+        encoding = self.create_clip_encoding(text=text, img=img, encoding=encoding).cuda()
         self.clip_encoding = encoding
 
     def image_output_path(self, sequence_number=None):


### PR DESCRIPTION
Added:
- an img can not be fed into Imagine (can be PIL Image or the path to a file that can be loaded with PIL.open. I added a transform pipeline that just resizes, takes the center crop and normalizes)
- a custom encoding can be used too (so users can do their embedding arithmetic and just feed in the CLIP feature vector)
- made the text in Imagine optional (this change might break some stuff in the CLI - we could also change this to be non-optional and just set it to None when not needed)
- added a setter such that the encoding of Imagine can be adjusted on the fly. See set_clip_encoding of Imagine (takes a text, img, or encoding as an input)
- adjusted the naming scheme for textpath, created a create_text_path() function that merges the name of the input image and the given text.


Please feel free to tell me what things to change or to adapt it as you like. I just thought other people would appreciate these features too.