### PR TITLE
(Suggestion) `--open-folder` parameter should default to False

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ FLAGS
         Default: None
         A seed to be used for deterministic runs.
     --open_folder=OPEN_FOLDER
-        Default: True
+        Default: False
         Whether or not to open a folder showing your generated images.
     --save_date_time=SAVE_DATE_TIME
         Default: False

--- a/deep_daze/cli.py
+++ b/deep_daze/cli.py
@@ -19,7 +19,7 @@ def train(
         overwrite=False,
         save_progress=True,
         seed=None,
-        open_folder=True,
+        open_folder=False,
         save_date_time=False,
         start_image_path=None,
         start_image_train_iters=50,


### PR DESCRIPTION
I've been having trouble with this parameter as a default. I realize it is probably a nice feature when it works well, but on my current setup it just sort of messes with my window layout. 