### PR TITLE
Fixed CLIP's limit in README.md and cli.py docs | Should be 77 tokens, not characters

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ SYNOPSIS
 
 POSITIONAL ARGUMENTS
     TEXT
-        (required) A phrase less than 77 characters which you would like to visualize.
+        (required) A phrase less than 77 tokens which you would like to visualize.
 
 FLAGS
     --img=IMAGE_PATH
@@ -118,7 +118,7 @@ FLAGS
         User-created custom CLIP encoding. If used, replaces any text or image that was used.
     --create_story=CREATE_STORY
         Default: False
-        Creates a story by optimizing each epoch on a new sliding-window of the input words. If this is enabled, much longer texts than 77 chars can be used. Requires save_progress to visualize the transitions of the story.
+        Creates a story by optimizing each epoch on a new sliding-window of the input words. If this is enabled, much longer texts than 77 tokens can be used. Requires save_progress to visualize the transitions of the story.
     --story_start_words=STORY_START_WORDS
         Default: 5
         Only used if create_story is True. How many words to optimize on for the first epoch.
@@ -248,7 +248,7 @@ The network's interpretation:
 
 
 ### New: Create a story
-The regular mode for texts only allows 77 characters. If you want to visualize a full story/paragraph/song/poem, set `create_story` to `True`.
+The regular mode for texts only allows 77 tokens. If you want to visualize a full story/paragraph/song/poem, set `create_story` to `True`.
 
 Given the poem “Stopping by Woods On a Snowy Evening” by Robert Frost - 
 "Whose woods these are I think I know. His house is in the village though; He will not see me stopping here To watch his woods fill up with snow. My little horse must think it queer To stop without a farmhouse near Between the woods and frozen lake The darkest evening of the year. He gives his harness bells a shake To ask if there is some mistake. The only other sound’s the sweep Of easy wind and downy flake. The woods are lovely, dark and deep, But I have promises to keep, And miles to go before I sleep, And miles to go before I sleep.".

--- a/deep_daze/cli.py
+++ b/deep_daze/cli.py
@@ -49,7 +49,7 @@ def train(
         optimizer="AdamP"
 ):
     """
-    :param text: (required) A phrase less than 77 characters which you would like to visualize.
+    :param text: (required) A phrase less than 77 tokens which you would like to visualize.
     :param img: The path to a jpg or png image which you would like to imagine. Can be combined with text.
     :param learning_rate: The learning rate of the neural net.
     :param hidden_size: The hidden layer size of the Siren net.
@@ -74,7 +74,7 @@ def train(
     :param upper_bound_cutout: The upper bound for the cutouts used in generation.
     :param lower_bound_cutout: The lower bound for the cutouts used in generation.
     :param saturate_bound: If True, the LOWER_BOUND_CUTOUT is linearly increased to 0.75 during training.
-    :param create_story: Creates a story by optimizing each epoch on a new sliding-window of the input words. If this is enabled, much longer texts than 77 chars can be used. Requires save_progress to visualize the transitions of the story.
+    :param create_story: Creates a story by optimizing each epoch on a new sliding-window of the input words. If this is enabled, much longer texts than 77 tokens can be used. Requires save_progress to visualize the transitions of the story.
     :param story_start_words: Only used if create_story is True. How many words to optimize on for the first epoch.
     :param story_words_per_epoch: Only used if create_story is True. How many words to add to the optimization goal per epoch after the first one.
     :param story_separator: Only used if create_story is True. Defines a separator like '.' that splits the text into groups for each epoch. Separator needs to be in the text otherwise it will be ignored!


### PR DESCRIPTION
CLIP can actually manage to handle a much larger input than just 77 characters, the context length refers to the amount of tokens it can accept. 77 tokens is roughly equivalent to... ~60 words? It depends on the content, and how CLIP decides to tokenize it.

You'll know when you've gone over that 77 token limit, since CLIP raises an error anyway.